### PR TITLE
Add missing Sailjail permissions to .desktop file

### DIFF
--- a/harbour-sailotp.desktop
+++ b/harbour-sailotp.desktop
@@ -5,3 +5,7 @@ Name=SailOTP
 Icon=harbour-sailotp
 Exec=harbour-sailotp
 
+[X-Sailjail]
+Permissions=UserDirs;RemovableMedia
+OrganizationName=org.seiichiro0185
+ApplicationName=harbour-otp


### PR DESCRIPTION
- Recent versions of SailfishOS have made permissions mandatory
- Without _UserDirs_ (for `/home/nemo`) or _RemovableMedia_ (for SD cards and USB-C sticks) SailOTP cannot Import/Export.