### PR TITLE
Make search and expiration info always visible on the main page

### DIFF
--- a/qml/pages/MainView.qml
+++ b/qml/pages/MainView.qml
@@ -104,32 +104,31 @@ Page {
   Column {
     anchors.fill: parent
 
-    PullDownMenu {
-      MenuItem {
-        text: qsTr("About")
-        onClicked: pageStack.push(Qt.resolvedUrl("About.qml"))
-      }
-      MenuItem {
-        text: qsTr("Settings")
-        visible: true
-        onClicked: pageStack.push(Qt.resolvedUrl("Settings.qml"))
-      }
-      MenuItem {
-        text: qsTr("Export / Import")
-        onClicked: pageStack.push(Qt.resolvedUrl("ExportPage.qml"), {parentPage: mainPage, mode: "export"})
-      }
-      MenuItem {
-        text: qsTr("Add Token")
-        onClicked: pageStack.push(Qt.resolvedUrl("ScanOTP.qml"), {parentPage: mainPage})
-      }
-    }
-
-
     SilicaListView {
       id: otpList
       model: appWin.listModel
       height: parent.height - updateProgress.height - searchField.height
       width: parent.width
+
+      PullDownMenu {
+        MenuItem {
+          text: qsTr("About")
+          onClicked: pageStack.push(Qt.resolvedUrl("About.qml"))
+        }
+        MenuItem {
+          text: qsTr("Settings")
+          visible: true
+          onClicked: pageStack.push(Qt.resolvedUrl("Settings.qml"))
+        }
+        MenuItem {
+          text: qsTr("Export / Import")
+          onClicked: pageStack.push(Qt.resolvedUrl("ExportPage.qml"), {parentPage: mainPage, mode: "export"})
+        }
+        MenuItem {
+          text: qsTr("Add Token")
+          onClicked: pageStack.push(Qt.resolvedUrl("ScanOTP.qml"), {parentPage: mainPage})
+        }
+      }
 
       ViewPlaceholder {
         enabled: otpList.count == 0

--- a/qml/pages/MainView.qml
+++ b/qml/pages/MainView.qml
@@ -322,11 +322,11 @@ Page {
         }
       }
       VerticalScrollDecorator{}
-
-      Component.onCompleted: {
-        // Load list of OTP-Entries
-        refreshOTPList();
-      }
     }
+  }
+
+  Component.onCompleted: {
+    // Load list of OTP-Entries
+    refreshOTPList();
   }
 }

--- a/qml/pages/MainView.qml
+++ b/qml/pages/MainView.qml
@@ -109,6 +109,7 @@ Page {
       model: appWin.listModel
       height: parent.height - updateProgress.height - searchField.height
       width: parent.width
+      clip: true
 
       PullDownMenu {
         MenuItem {

--- a/qml/pages/MainView.qml
+++ b/qml/pages/MainView.qml
@@ -101,7 +101,7 @@ Page {
     onTriggered: refreshOTPValues();
   }
 
-  SilicaFlickable {
+  Column {
     anchors.fill: parent
 
     PullDownMenu {
@@ -127,8 +127,8 @@ Page {
 
     SilicaListView {
       id: otpList
-      anchors.fill: parent
       model: appWin.listModel
+      height: parent.height - updateProgress.height - searchField.height
       width: parent.width
 
       ViewPlaceholder {
@@ -137,53 +137,8 @@ Page {
         hintText: qsTr("Pull down to add a OTP")
       }
 
-      header: Column {
-        width: parent.width
-        height: headerRow.height + searchRow.height
-        Row {
-          id: headerRow
-          height: Theme.itemSizeSmall
-          width: parent.width
-          ProgressBar {
-            id: updateProgress
-            anchors.topMargin: Theme.paddingLarge * 1.15
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            height: parent.height
-            width: parent.width * 0.65
-            maximumValue: 29
-            value: 29 - seconds_global
-            // Only show when there are enries
-            visible: appWin.listModel.count
-          }
-          PageHeader {
-            id: header
-            anchors.top: parent.top
-            height: Theme.itemSizeSmall
-            width: parent.width * 0.35
-            title: "SailOTP"
-          }
-        }
-        Row {
-          id: searchRow
-          width: parent.width
-          SearchField {
-            id: searchField
-            font.pixelSize: Theme.fontSizeMedium
-            width: parent.width
-// This would be useful, but seems to break the button altogether. Perhaps it'll work later?
-//            canHide: true
-            EnterKey.enabled: false
-            inputMethodHints: Qt.ImhNoPredictiveText // Qt.ImhPreferUppercase | Qt.ImhNoAutoUppercase
-            placeholderText: qsTr("Search")
-            onTextChanged: {
-              searchTerm = searchField.text
-              for (var i = 0; i < appWin.listModel.count; i++) {
-                appWin.listModel.get(i).itemVisible = appWin.listModel.get(i).title.toString().toLowerCase().indexOf(searchField.text.toLowerCase()) > -1
-              }
-            }
-          }
-        }
+      header: PageHeader {
+        title: "SailOTP"
       }
 
       delegate: ListItem {
@@ -322,6 +277,33 @@ Page {
         }
       }
       VerticalScrollDecorator{}
+    }
+
+    SearchField {
+      id: searchField
+      font.pixelSize: Theme.fontSizeMedium
+      width: parent.width
+      // This would be useful, but seems to break the button altogether. Perhaps it'll work later?
+      //            canHide: true
+      EnterKey.enabled: false
+      inputMethodHints: Qt.ImhNoPredictiveText // Qt.ImhPreferUppercase | Qt.ImhNoAutoUppercase
+      placeholderText: qsTr("Search")
+      onTextChanged: {
+        searchTerm = searchField.text
+        for (var i = 0; i < appWin.listModel.count; i++) {
+          appWin.listModel.get(i).itemVisible = appWin.listModel.get(i).title.toString().toLowerCase().indexOf(searchField.text.toLowerCase()) > -1
+        }
+      }
+    }
+
+    ProgressBar {
+      id: updateProgress
+      height: Theme.itemSizeSmall
+      width: parent.width
+      maximumValue: 29
+      value: 29 - seconds_global
+      // Only show when there are enries
+      visible: appWin.listModel.count
     }
   }
 

--- a/qml/pages/MainView.qml
+++ b/qml/pages/MainView.qml
@@ -95,7 +95,7 @@ Page {
 
   Timer {
     interval: 500
-    // Timer only runs when app is acitive and we have entries
+    // Timer only runs when app is active and we have entries
     running: Qt.application.active && appWin.listModel.count
     repeat: true
     onTriggered: refreshOTPValues();


### PR DESCRIPTION
When scrolling through the list of OTP, the search bar and the progress bar that indicates when the OTP will be refreshed at the top of the page are not visible anymore:


|Top of the list|Bottom of the list|
|---|---|
| ![Top of the OTP list](https://github.com/user-attachments/assets/edfb88bc-96fd-469e-b325-497a2b232769) | ![Bottom of the OTP list](https://github.com/user-attachments/assets/7c3a7a22-1fdf-48ba-8705-8c648722bbb4) |
| Widget at the top of the page are visible when we are at the top of the list. | Widgets at the top of the page are not visible when we are at the bottom of the list. |
||Side note: the pulley menu cannot be used from there and is not visible in such a context in other Sailfish OS applications.|

This PR attempts to improve the way this information is displayed by moving this components at the bottom of the page and making sure they are always displayed, even when scrolling through a long list of OTP:

|Top of the list|Bottom of the list|
|---|---|
| ![Top of the OTP list](https://github.com/user-attachments/assets/2a857b58-0f5a-4094-a001-75a66394d3d6) | ![V](https://github.com/user-attachments/assets/b65d8d6e-2b79-4643-9d2d-f126957d70ec) |
| Widget at the bottom of the page are visible when we are at the top of the list. | Widgets at the bottom of the page are still visible when we are at the bottom of the list. |

I did my best to split the changes into multiple commits to make it easier to review the changes.  The intermediates commit might not be working as expected.